### PR TITLE
fix(example): fix errors in example file

### DIFF
--- a/examples/spdx2_document_from_scratch.py
+++ b/examples/spdx2_document_from_scratch.py
@@ -88,7 +88,7 @@ package = Package(
 document.packages = [package]
 
 # A DESCRIBES relationship asserts that the document indeed describes the package.
-describes_relationship = Relationship("SPDXRef-Document", RelationshipType.DESCRIBES, "SPDXRef-Package")
+describes_relationship = Relationship("SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, "SPDXRef-Package")
 document.relationships = [describes_relationship]
 
 # Let's add two files. Have a look at the file class for all possible properties a file can have.
@@ -120,6 +120,7 @@ contains_relationship2 = Relationship("SPDXRef-Package", RelationshipType.CONTAI
 # This library uses run-time type checks when assigning properties.
 # Because in-place alterations like .append() circumvent these checks, we don't use them here.
 document.relationships += [contains_relationship1, contains_relationship2]
+document.files += [file1, file2]
 
 # We now have created a document with basic creation information, describing a package that contains two files.
 # You can also add Annotations, Snippets and ExtractedLicensingInfo to the document in an analogous manner to the above.


### PR DESCRIPTION
Fix the following error/warnings in example script for creating documents from scratch.

```
WARNING:root:did not find the referenced spdx_id "SPDXRef-Document" in the SPDX document
WARNING:root:ValidationContext(spdx_id=None, parent_id=None, element_type=<SpdxElementType.RELATIONSHIP: 13>, full_element=Relationship(spdx_element_id='SPDXRef-Document', relationship_type=<RelationshipType.DESCRIBES: 14>, related_spdx_element_id='SPDXRef-Package', comment=None))
WARNING:root:did not find the referenced spdx_id "SPDXRef-File1" in the SPDX document
WARNING:root:ValidationContext(spdx_id=None, parent_id=None, element_type=<SpdxElementType.RELATIONSHIP: 13>, full_element=Relationship(spdx_element_id='SPDXRef-Package', relationship_type=<RelationshipType.CONTAINS: 6>, related_spdx_element_id='SPDXRef-File1', comment=None))
WARNING:root:did not find the referenced spdx_id "SPDXRef-File2" in the SPDX document
WARNING:root:ValidationContext(spdx_id=None, parent_id=None, element_type=<SpdxElementType.RELATIONSHIP: 13>, full_element=Relationship(spdx_element_id='SPDXRef-Package', relationship_type=<RelationshipType.CONTAINS: 6>, related_spdx_element_id='SPDXRef-File2', comment=None))
```

Add the files to package and update the SPDX id describing relationship between document and package.